### PR TITLE
Add support for converting Excel, Visio and Powerpoint file formats

### DIFF
--- a/apps/unoserver/Dockerfile
+++ b/apps/unoserver/Dockerfile
@@ -9,7 +9,7 @@ FROM node:lts-bookworm
 WORKDIR /app
 
 RUN apt-get update; \
-    apt-get install --no-install-recommends --yes python3-full python3-pip virtualenv unoconv libreoffice-java-common libreoffice-writer default-jre; \
+    apt-get install --no-install-recommends --yes python3-full python3-pip virtualenv unoconv libreoffice-java-common libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-draw default-jre; \
     virtualenv --python=/usr/bin/python3 --system-site-packages virtenv; \
     virtenv/bin/pip install unoserver==2.0.1; \
     apt-get clean; \


### PR DESCRIPTION
Add libreoffice-calc, libreoffice-impress and libreoffice-draw packages to support converting Excel, Visio and Powerpoint file formats to PDF in the unoserver container.