### PR TITLE
disable PushMessaging to remove error message

### DIFF
--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -23,6 +23,7 @@ export class BrowserToPdfRenderer {
           '--enable-font-antialiasing',
           '--font-render-hinting=none',
           '--disable-dev-shm-usage',
+          '--disable-features=PushMessaging',
         ],
       });
       this.launchedBrowser.process()?.stdout?.pipe(process.stdout);


### PR DESCRIPTION
  [14:43:0630/195237.175358:ERROR:google_apis/gcm/engine/registration_request.cc:291] Registration response error message: PHONE_REGISTRATION_ERROR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated browser configuration to disable Push Messaging when generating PDFs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->