### PR TITLE
use zod/v4

### DIFF
--- a/apps/pdftk/src/schema.ts
+++ b/apps/pdftk/src/schema.ts
@@ -1,4 +1,4 @@
-import { type RawCreateParams, z } from 'zod';
+import { z } from 'zod/v4';
 
 export const outputSchema = z.strictObject({
   owner_pw: z.string().optional(),

--- a/libs/binary/pdftk/src/lib/decrypt.ts
+++ b/libs/binary/pdftk/src/lib/decrypt.ts
@@ -1,6 +1,6 @@
 import type { Readable, Writable } from 'node:stream';
 import { streamChildProcess } from '@container/stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { type PdftkOptions, pdftk } from './pdftk';
 
 export const decryptSchema = z.strictObject({

--- a/libs/binary/pdftk/src/lib/encrypt.ts
+++ b/libs/binary/pdftk/src/lib/encrypt.ts
@@ -1,6 +1,6 @@
 import type { Readable, Writable } from 'node:stream';
 import { streamChildProcess } from '@container/stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { type PdftkOptions, pdftk } from './pdftk';
 
 export const encryptSchema = z.strictObject({

--- a/libs/binary/pdftk/src/lib/form-fill.ts
+++ b/libs/binary/pdftk/src/lib/form-fill.ts
@@ -3,7 +3,7 @@ import { createReadStream, createWriteStream, existsSync, unlink } from 'node:fs
 import { cwd } from 'node:process';
 import type { Readable, Writable } from 'node:stream';
 import { finished } from 'node:stream/promises';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { type DataFieldType, dataFields } from './data-fields';
 import { type PdftkOptions, pdftk } from './pdftk';
 

--- a/libs/binary/puppeteer/src/lib/body-schema.ts
+++ b/libs/binary/puppeteer/src/lib/body-schema.ts
@@ -1,7 +1,10 @@
 import type { PaperFormat } from 'puppeteer-core';
-import { type RawCreateParams, z } from 'zod';
+import { type core, z } from 'zod/v4';
 
-function paperFormatUnion(values: readonly [PaperFormat, PaperFormat, ...PaperFormat[]], params?: RawCreateParams) {
+function paperFormatUnion(
+  values: readonly [PaperFormat, PaperFormat, ...PaperFormat[]],
+  params?: core.$ZodUnionParams,
+) {
   return z.union(
     [
       z.literal<PaperFormat>(values[0]),

--- a/libs/binary/puppeteer/src/lib/query-schema.ts
+++ b/libs/binary/puppeteer/src/lib/query-schema.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { ScreenshotType } from './screenshot-type';
 
 export const querySchema = z.strictObject({
-  type: z.nativeEnum(ScreenshotType).optional().default(ScreenshotType.png),
+  type: z.enum(ScreenshotType).optional().default(ScreenshotType.png),
 });

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { cwd } from 'node:process';
 import puppeteer, { type Browser } from 'puppeteer-core';
-import type { TypeOf } from 'zod';
+import type { output } from 'zod/v4';
 import type { bodySchema } from './body-schema';
 import { ScreenshotType } from './screenshot-type';
 
@@ -43,7 +43,7 @@ export class BrowserToPdfRenderer {
   }
 
   public async renderTo(
-    schema: TypeOf<typeof bodySchema>,
+    schema: output<typeof bodySchema>,
     { type, imageType = ScreenshotType.png }: { type: 'pdf' | 'image'; imageType?: ScreenshotType },
   ) {
     const browser = await this.browser();

--- a/libs/binary/unoserver/src/lib/schema.ts
+++ b/libs/binary/unoserver/src/lib/schema.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { ConvertTo } from './convert-to';
 
 export const schema = z.strictObject({
-  convertTo: z.nativeEnum(ConvertTo).optional().default(ConvertTo.pdf),
+  convertTo: z.enum(ConvertTo).optional().default(ConvertTo.pdf),
 });

--- a/libs/http/body/src/lib/request-to-json.ts
+++ b/libs/http/body/src/lib/request-to-json.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 import { BadRequest } from '@container/http/error';
 import { streamToJson } from '@container/stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { validateRequestHeaders } from './validate-request-headers';
 
 export const applicationJSON = z.object({

--- a/libs/http/body/src/lib/request-to-multipart-form-data/request-to-multipart-form-data.ts
+++ b/libs/http/body/src/lib/request-to-multipart-form-data/request-to-multipart-form-data.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { Readable, Transform } from 'node:stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { validateRequestHeaders } from '../validate-request-headers';
 import { getBoundary } from './get-boundary';
 

--- a/libs/http/body/src/lib/request-to-text.ts
+++ b/libs/http/body/src/lib/request-to-text.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { streamToString } from '@container/stream';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { validateRequestHeaders } from './validate-request-headers';
 
 export const textPlain = z.object({

--- a/libs/http/body/src/lib/validate-request-headers.ts
+++ b/libs/http/body/src/lib/validate-request-headers.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage } from 'node:http';
 import { BadRequest } from '@container/http/error';
-import type { ZodType } from 'zod';
+import type { ZodObject } from 'zod/v4';
 
-export const validateRequestHeaders = (req: IncomingMessage, type: ZodType): void => {
+export const validateRequestHeaders = (req: IncomingMessage, type: ZodObject): void => {
   const test = type.safeParse(req.headers);
   if (test.success === false) {
     throw new BadRequest('Invalid request headers');

--- a/libs/http/multipart-form-data/src/lib/http-multipart-form-data.ts
+++ b/libs/http/multipart-form-data/src/lib/http-multipart-form-data.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { BadRequest } from '@container/http/error';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const multipartFormData = z.object({
   'content-type': z.literal('multipart/form-data'),

--- a/libs/http/validate/src/lib/body.ts
+++ b/libs/http/validate/src/lib/body.ts
@@ -1,11 +1,11 @@
 import { requestToJson } from '@container/http/body';
 import { BadRequest } from '@container/http/error';
 import type { Next, Prefix, ReqRes } from '@container/http/route';
-import type { TypeOf, ZodSchema } from 'zod';
+import type { output, ZodType } from 'zod/v4';
 
-export function validateBody<RQ extends ReqRes, BodySchema extends ZodSchema>(
+export function validateBody<RQ extends ReqRes, BodySchema extends ZodType>(
   schema: BodySchema,
-): (params: RQ) => Promise<TypeOf<BodySchema>> {
+): (params: RQ) => Promise<output<BodySchema>> {
   return async (params: RQ) => {
     const data = await requestToJson(params.req);
     const body = await schema.safeParseAsync(data);
@@ -20,20 +20,20 @@ export function nextBody<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Input,
-  BodySchema extends ZodSchema,
->(schema: BodySchema, next: Next<ParamKey, Output & Record<'body', TypeOf<BodySchema>>>): Next<ParamKey, Input>;
+  BodySchema extends ZodType,
+>(schema: BodySchema, next: Next<ParamKey, Output & Record<'body', output<BodySchema>>>): Next<ParamKey, Input>;
 export function nextBody<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Input,
-  BodySchema extends ZodSchema,
+  BodySchema extends ZodType,
   Key extends string = 'body',
->(schema: BodySchema, key: Key, next: Next<ParamKey, Output & Record<Key, TypeOf<BodySchema>>>): Next<ParamKey, Input>;
+>(schema: BodySchema, key: Key, next: Next<ParamKey, Output & Record<Key, output<BodySchema>>>): Next<ParamKey, Input>;
 export function nextBody<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Input,
-  BodySchema extends ZodSchema,
+  BodySchema extends ZodType,
 >(...args: unknown[]): Next<ParamKey, Output> {
   const [schema, key, next] = (() => {
     if (args.length === 2) {
@@ -50,7 +50,7 @@ export function nextBody<
 
 export const middlewareBody =
   <
-    BodySchema extends ZodSchema,
+    BodySchema extends ZodType,
     ParamKey extends string,
     RQ extends Prefix<ParamKey, ReqRes>,
     Key extends string = 'body',
@@ -58,7 +58,7 @@ export const middlewareBody =
     schema: BodySchema,
     key?: Key,
   ) =>
-  async (params: RQ): Promise<RQ & Record<Key, TypeOf<BodySchema>>> => {
+  async (params: RQ): Promise<RQ & Record<Key, output<BodySchema>>> => {
     const validBody = await validateBody(schema)(params);
-    return { ...params, [key ?? 'body']: validBody } as RQ & Record<Key, TypeOf<BodySchema>>;
+    return { ...params, [key ?? 'body']: validBody } as RQ & Record<Key, output<BodySchema>>;
   };

--- a/libs/http/validate/src/lib/query.ts
+++ b/libs/http/validate/src/lib/query.ts
@@ -1,10 +1,10 @@
 import { BadRequest } from '@container/http/error';
 import type { Next, Prefix, ReqRes } from '@container/http/route';
-import type { TypeOf, ZodSchema } from 'zod';
+import type { output, ZodType } from 'zod/v4';
 
-export function validateQuery<RQ extends ReqRes, QuerySchema extends ZodSchema>(
+export function validateQuery<RQ extends ReqRes, QuerySchema extends ZodType>(
   schema: QuerySchema,
-): (params: RQ) => Promise<TypeOf<QuerySchema>> {
+): (params: RQ) => Promise<output<QuerySchema>> {
   return async (params: RQ) => {
     const url = new URL(params.req.url || '', `http://${params.req.headers.host}`);
     const data = Object.fromEntries(url.searchParams);
@@ -20,24 +20,24 @@ export function nextQuery<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Input,
-  QuerySchema extends ZodSchema,
->(schema: QuerySchema, next: Next<ParamKey, Output & Record<'query', TypeOf<QuerySchema>>>): Next<ParamKey, Input>;
+  QuerySchema extends ZodType,
+>(schema: QuerySchema, next: Next<ParamKey, Output & Record<'query', output<QuerySchema>>>): Next<ParamKey, Input>;
 export function nextQuery<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Prefix<ParamKey, ReqRes>,
-  QuerySchema extends ZodSchema,
+  QuerySchema extends ZodType,
   Key extends string = 'query',
 >(
   schema: QuerySchema,
   key: Key,
-  next: Next<ParamKey, Output & Record<Key, TypeOf<QuerySchema>>>,
+  next: Next<ParamKey, Output & Record<Key, output<QuerySchema>>>,
 ): Next<ParamKey, Input>;
 export function nextQuery<
   ParamKey extends string,
   Input extends Prefix<ParamKey, ReqRes>,
   Output extends Input,
-  QuerySchema extends ZodSchema,
+  QuerySchema extends ZodType,
 >(...args: unknown[]): Next<ParamKey, Output> {
   const [schema, key, next] = (() => {
     if (args.length === 2) {
@@ -55,14 +55,14 @@ export function nextQuery<
 export const middlewareQuery =
   <
     ParamKey extends string,
-    QuerySchema extends ZodSchema,
+    QuerySchema extends ZodType,
     RQ extends Prefix<ParamKey, ReqRes>,
     Key extends string = 'query',
   >(
     schema: QuerySchema,
     key?: Key,
   ) =>
-  async (params: RQ): Promise<RQ & Record<Key, TypeOf<QuerySchema>>> => {
+  async (params: RQ): Promise<RQ & Record<Key, output<QuerySchema>>> => {
     const validQuery = await validateQuery(schema)(params);
-    return { ...params, [key ?? 'query']: validQuery } as RQ & Record<Key, TypeOf<QuerySchema>>;
+    return { ...params, [key ?? 'query']: validQuery } as RQ & Record<Key, output<QuerySchema>>;
   };

--- a/libs/http/validate/src/lib/validate-combo.spec.ts
+++ b/libs/http/validate/src/lib/validate-combo.spec.ts
@@ -1,8 +1,7 @@
-import type { Server } from 'node:http';
-import { post, put, routes } from '@container/http/route';
-import { testServer, useTestServer } from '@container/test/server';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { z } from 'zod';
+import { post, put } from '@container/http/route';
+import { useTestServer } from '@container/test/server';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
 import { middlewareBody, nextBody } from './body';
 import { middlewareQuery, nextQuery } from './query';
 

--- a/libs/http/validate/src/lib/validate-single.spec.ts
+++ b/libs/http/validate/src/lib/validate-single.spec.ts
@@ -1,8 +1,7 @@
-import type { Server } from 'node:http';
-import { get, post, routes } from '@container/http/route';
-import { testServer, useTestServer } from '@container/test/server';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { z } from 'zod';
+import { get, post } from '@container/http/route';
+import { useTestServer } from '@container/test/server';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
 import { middlewareBody, nextBody } from './body';
 import { middlewareQuery, nextQuery } from './query';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated type imports and usage to use explicit versioned imports from Zod v4 for improved type safety and consistency.
  * Adjusted function and method signatures in validation utilities to align with updated Zod v4 typings, affecting type annotations for schemas and outputs.
  * Modified enum validation methods in schemas for consistency.

* **Style**
  * Cleaned up and simplified import statements across several files.

* **Tests**
  * Updated test files to use Zod v4 imports and removed unused imports for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->