### PR TITLE
remove docker proxy harbor.riwi.dev

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -2,23 +2,15 @@ name: Docker Setup
 description: install buildx, qemu and docker login
 inputs:
   docker-username:
-    description: 'docker username'
+    description: "docker username"
     required: false
-    default: ''
+    default: ""
   docker-password:
-    description: 'docker password'
+    description: "docker password"
     required: false
-    default: ''
-  harbor-username:
-    description: 'harbor username'
-    required: false
-    default: ''
-  harbor-password:
-    description: 'harbor password'
-    required: false
-    default: ''
+    default: ""
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -44,11 +36,3 @@ runs:
       with:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
-
-    - name: Login to harbor.riwi.dev
-      uses: docker/login-action@v3
-      if: ${{ inputs.harbor-username != '' && inputs.harbor-password != '' }}
-      with:
-        registry: harbor.riwi.dev
-        username: ${{ inputs.harbor-username }}
-        password: ${{ inputs.harbor-password }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -82,8 +82,6 @@ jobs:
         with:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-password: ${{ secrets.DOCKERHUB_TOKEN }}
-          harbor-username: ${{ secrets.HARBOR_USERNAME }}
-          harbor-password: ${{ secrets.HARBOR_TOKEN }}
 
       - name: corepack enable
         shell: bash
@@ -138,8 +136,6 @@ jobs:
         with:
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-password: ${{ secrets.DOCKERHUB_TOKEN }}
-          harbor-username: ${{ secrets.HARBOR_USERNAME }}
-          harbor-password: ${{ secrets.HARBOR_TOKEN }}
 
       - name: corepack enable
         shell: bash

--- a/apps/mailcatcher/Dockerfile
+++ b/apps/mailcatcher/Dockerfile
@@ -2,7 +2,7 @@
 # MailCatcher Dockerfile
 #
 
-FROM harbor.riwi.dev/hub/ruby:3.4.5-trixie AS bundler
+FROM ruby:3.4.5-trixie AS bundler
 
 LABEL org.opencontainers.image.authors="philiplehmann@gmail.com"
 
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get install --no-install-recommends --yes build-essential pkg-config sqlite3 libsqlite3-dev && \
     gem install mailcatcher --version ${MAILCATCHER_VERSION} --no-document
 
-FROM harbor.riwi.dev/hub/ruby:3.4.5-slim-trixie AS runner
+FROM ruby:3.4.5-slim-trixie AS runner
 
 COPY --from=bundler /usr/local/bundle /usr/local/bundle
 

--- a/apps/mailhog/Dockerfile
+++ b/apps/mailhog/Dockerfile
@@ -2,7 +2,7 @@
 # MailHog Dockerfile
 #
 
-FROM harbor.riwi.dev/hub/golang:tip-20250808-trixie AS builder
+FROM golang:tip-20250808-trixie AS builder
 
 LABEL org.opencontainers.image.authors="philiplehmann@gmail.com"
 
@@ -12,7 +12,7 @@ ARG MAILHOG_VERSION
 RUN mkdir -p /root/gocode && \
     GOSUMDB=off GOPATH=/root/gocode GOPROXY=https://proxy.golang.org/cached-only go install github.com/mailhog/MailHog@${MAILHOG_VERSION}
 
-FROM harbor.riwi.dev/hub/debian:trixie-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get upgrade --yes
 RUN useradd -ms /bin/bash -u 1000 mailhog
 

--- a/apps/pdftk/Dockerfile
+++ b/apps/pdftk/Dockerfile
@@ -4,7 +4,7 @@
 # Tip: Modify "docker-build" options in project.json to change docker build args.
 #
 # Run the container with `docker run -p 3000:3000 -t philiplehmann/pdftk`.
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim AS pdftk
+FROM node:24.6.0-trixie-slim AS pdftk
 
 ARG PDFTK_VERSION
 ARG TARGETPLATFORM
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     curl -L "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jre_${JDK_ARCH}_linux_hotspot_11.0.28_6.tar.gz" | tar --strip-components=1 -C /java -zxivf  -
 
 
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim
+FROM node:24.6.0-trixie-slim
 
 ARG JRE_VERSION
 

--- a/apps/poppler/Dockerfile
+++ b/apps/poppler/Dockerfile
@@ -4,7 +4,7 @@
 # Tip: Modify "docker-build" options in project.json to change docker build args.
 #
 # Run the container with `docker run -p 3000:3000 -t poppler`.
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim
+FROM node:24.6.0-trixie-slim
 
 LABEL org.opencontainers.image.authors="philiplehmann@gmail.com"
 

--- a/apps/puppeteer/Dockerfile
+++ b/apps/puppeteer/Dockerfile
@@ -4,7 +4,7 @@
 # Tip: Modify "docker-build" options in project.json to change docker build args.
 #
 # Run the container with `docker run -p 3000:3000 -t puppeteer`.
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim
+FROM node:24.6.0-trixie-slim
 
 ENV NODE_ENV=production
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/apps/tesseract/Dockerfile
+++ b/apps/tesseract/Dockerfile
@@ -4,7 +4,7 @@
 # Tip: Modify "docker-build" options in project.json to change docker build args.
 #
 # Run the container with `docker run -p 3000:3000 -t philiplehmann/tesseract`.
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim
+FROM node:24.6.0-trixie-slim
 
 ENV HOST=0.0.0.0
 ENV PORT=3000

--- a/apps/unoserver/Dockerfile
+++ b/apps/unoserver/Dockerfile
@@ -4,7 +4,7 @@
 # Tip: Modify "docker-build" options in project.json to change docker build args.
 #
 # Run the container with `docker run -p 3000:3000 -t philiplehmann/unoserver`.
-FROM harbor.riwi.dev/hub/node:24.6.0-trixie-slim
+FROM node:24.6.0-trixie-slim
 
 ARG UNOSERVER_VERSION
 ARG JRE_VERSION

--- a/nx.json
+++ b/nx.json
@@ -70,8 +70,8 @@
     }
   ],
   "s3": {
-    "endpoint": "https://data.riwi.dev",
-    "region": "public",
+    "endpoint": "https://storage.datage.ch",
+    "region": "hetzner",
     "bucket": "nx-cache",
     "forcePathStyle": true,
     "localMode": "read-write"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized Docker base images to official Docker Hub variants for mailcatcher, mailhog, pdftk, poppler, puppeteer, tesseract, and unoserver; no runtime behavior changes.
  - Simplified CI workflows by removing Harbor credentials and Harbor login steps; Docker Hub login retained where used.
  - Updated S3 storage configuration endpoint and region in project configuration.
  - Applied minor YAML quoting consistency updates in GitHub Actions and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->