### PR TITLE
process management in unoserver direct-fs

### DIFF
--- a/apps/unoserver/README.md
+++ b/apps/unoserver/README.md
@@ -9,6 +9,7 @@ A containerized Node.js service that provides a REST API for converting office d
 - 🐳 **Docker Ready** - Easy deployment with Docker
 - 🔧 **REST API** - Simple HTTP interface
 - ⚙️ **Flexible Options** - Control filters, page ranges, and output behavior
+- 🧭 **Process Management** - Track, inspect, and terminate conversion processes
 
 ## Quick Start
 
@@ -32,6 +33,8 @@ services:
 ## API Endpoints
 
 Default behavior remains unchanged: only `/convert` and `/direct` are available unless `UNOSERVER_FS_ENABLE=true` is explicitly set.
+
+When process tracking is enabled (`UNOSERVER_PROCESS_ENABLED=true`), conversions triggered through `/convert`, `/direct`, and `/direct-fs` are tracked in `/processes`.
 
 ### Convert File
 
@@ -101,7 +104,7 @@ docker run --rm \
   -e UNOSERVER_DIRECT_ONLY=true \
   -e UNOSERVER_FS_ENABLE=true \
   -e UNOSERVER_FS_INPUT_ROOT=/data/in \
-  -e UNOSERVER_FS_OUTPUT_ROOT=/data/out \/
+  -e UNOSERVER_FS_OUTPUT_ROOT=/data/out \
   -v "$PWD/tmp/in:/data/in" \
   -v "$PWD/tmp/out:/data/out" \
   philiplehmann/unoserver:latest
@@ -115,7 +118,8 @@ curl -X POST \
   -d '{
     "inputPath": "dummy.docx",
     "outputPath": "dummy.pdf",
-    "convertTo": "pdf"
+    "convertTo": "pdf",
+    "timeoutMs": 10000
   }' \
   'http://localhost:3000/direct-fs'
 ```
@@ -220,6 +224,21 @@ curl -X POST \
   'http://localhost:3000/convert?quiet=true'
 ```
 
+### `timeoutMs`
+
+Optional timeout in milliseconds. If the timeout is reached, the conversion process is killed with `SIGKILL` and is reported as `killed` in process management.
+
+Supported on:
+- `/convert` (query parameter)
+- `/direct` (query parameter)
+- `/direct-fs` (JSON body)
+
+```bash
+curl -X POST \
+  --data-binary "@apps/unoserver/src/test/assets/dummy.docx" --output tmp/document.pdf \
+  'http://localhost:3000/convert?timeoutMs=10000'
+```
+
 ## Ports
 
 | Port | Service | Description |
@@ -260,6 +279,10 @@ curl 'http://localhost:3000/processes'
 # Filter by status (running, completed, failed, killed)
 curl 'http://localhost:3000/processes?status=running'
 ```
+
+Timeout behavior:
+- Timed out conversions are force-killed (`SIGKILL`) and appear with `status: killed`
+- Query timed out conversions via `curl 'http://localhost:3000/processes?status=killed'`
 
 ### Get Process Details
 

--- a/apps/unoserver/src/test/unoserver-process.spec.ts
+++ b/apps/unoserver/src/test/unoserver-process.spec.ts
@@ -1,4 +1,7 @@
-import { describe } from 'bun:test';
+import { afterAll, describe } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { currentArch } from '@riwi/docker';
@@ -35,6 +38,134 @@ describe('unoserver', () => {
                 path: '/convert',
                 file,
               });
+            },
+          );
+        });
+      });
+
+      describe('/direct', async () => {
+        const setup = useTestContainer({
+          image: `philiplehmann/unoserver:test-${arch}`,
+          containerPort,
+          env: {
+            UNOSERVER_PROCESS_ENABLED: 'true',
+            UNOSERVER_DIRECT_ONLY: 'true',
+          },
+          hook: (container) => {
+            return container.withStartupTimeout(60_000);
+          },
+          timeout: 90_000,
+        });
+
+        describe('process management', () => {
+          createProcessEndpointTests(
+            () => setup.port,
+            async (port) => {
+              const file = resolve(__dirname, 'assets/VorlageBusinessplan.doc');
+              await testRequest({
+                method: 'POST',
+                host: 'localhost',
+                port,
+                path: '/direct',
+                file,
+              });
+            },
+            {
+              triggerFailingProcess: async (port) => {
+                const file = resolve(__dirname, 'assets/VorlageBusinessplan.doc');
+                await testRequest({
+                  method: 'POST',
+                  host: 'localhost',
+                  port,
+                  path: '/direct?outputFilter=invalid_filter_name',
+                  file,
+                });
+              },
+              triggerTimeoutProcess: async (port) => {
+                const file = resolve(__dirname, 'assets/VorlageBusinessplan.doc');
+                await testRequest({
+                  method: 'POST',
+                  host: 'localhost',
+                  port,
+                  path: '/direct?timeoutMs=1',
+                  file,
+                });
+              },
+            },
+          );
+        });
+      });
+
+      describe('/direct-fs', async () => {
+        const inputRoot = resolve(__dirname, 'assets');
+        let outputRoot = '';
+
+        afterAll(async () => {
+          if (outputRoot) {
+            try {
+              await rm(outputRoot, { recursive: true, force: true });
+            } catch (e) {
+              console.error(e);
+            }
+          }
+        });
+
+        const setup = useTestContainer({
+          image: `philiplehmann/unoserver:test-${arch}`,
+          containerPort,
+          env: {
+            UNOSERVER_PROCESS_ENABLED: 'true',
+            UNOSERVER_DIRECT_ONLY: 'true',
+            UNOSERVER_FS_ENABLE: 'true',
+          },
+          hook: async (container) => {
+            outputRoot = await mkdtemp(resolve(tmpdir(), 'unoserver-process-out-'));
+            execSync(`chmod 777 "${outputRoot}"`);
+            return container.withStartupTimeout(60_000).withBindMounts([
+              { source: inputRoot, target: '/data/in' },
+              { source: outputRoot, target: '/data/out' },
+            ]);
+          },
+          timeout: 90_000,
+        });
+
+        describe('process management', () => {
+          createProcessEndpointTests(
+            () => setup.port,
+            async (port) => {
+              await testRequest({
+                method: 'POST',
+                host: 'localhost',
+                port,
+                path: '/direct-fs',
+                headers: {
+                  'content-type': 'application/json',
+                },
+                body: JSON.stringify({
+                  inputPath: 'VorlageBusinessplan.doc',
+                  outputPath: `converted/success-${Date.now()}.pdf`,
+                  convertTo: 'pdf',
+                }),
+              });
+            },
+            {
+              triggerFailingProcess: async (port) => {
+                await testRequest({
+                  method: 'POST',
+                  host: 'localhost',
+                  port,
+                  path: '/direct-fs',
+                  headers: {
+                    'content-type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    inputPath: 'VorlageBusinessplan.doc',
+                    outputPath: `converted/failed-${Date.now()}.pdf`,
+                    convertTo: 'pdf',
+                    outputFilter: 'invalid_filter_name',
+                  }),
+                });
+              },
             },
           );
         });

--- a/libs/binary/libreoffice-fs/src/lib/convert.ts
+++ b/libs/binary/libreoffice-fs/src/lib/convert.ts
@@ -8,6 +8,7 @@ export interface DirectFsConvertOptions {
   convertTo: LibreofficeSchema['convertTo'];
   outputFilter?: LibreofficeSchema['outputFilter'];
   filterOptions?: LibreofficeSchema['filterOptions'];
+  timeoutMs?: LibreofficeSchema['timeoutMs'];
 }
 
 export interface ConvertOptions {
@@ -18,6 +19,7 @@ export interface ConvertOptions {
   convertTo: LibreofficeSchema['convertTo'];
   outputFilter?: LibreofficeSchema['outputFilter'];
   filterOptions?: LibreofficeSchema['filterOptions'];
+  timeoutMs?: LibreofficeSchema['timeoutMs'];
 }
 
 export async function convert(options: ConvertOptions): Promise<DirectFsConvertResult> {
@@ -30,5 +32,6 @@ export async function convert(options: ConvertOptions): Promise<DirectFsConvertR
     convertTo: options.convertTo,
     outputFilter: options.outputFilter,
     filterOptions: options.filterOptions,
+    timeoutMs: options.timeoutMs,
   });
 }

--- a/libs/binary/libreoffice-fs/src/lib/directFsConvert.ts
+++ b/libs/binary/libreoffice-fs/src/lib/directFsConvert.ts
@@ -17,6 +17,7 @@ export async function directFsConvert({
   convertTo,
   outputFilter,
   filterOptions,
+  timeoutMs,
 }: DirectFsConvertOptions): Promise<DirectFsConvertResult> {
   await assertReadableInputFile(inputAbsolutePath);
   await mkdir(dirname(outputAbsolutePath), { recursive: true });
@@ -29,6 +30,7 @@ export async function directFsConvert({
     convertTo,
     outputFilter,
     filterOptions,
+    timeoutMs,
   });
 
   const outputStats = await stat(outputAbsolutePath);

--- a/libs/binary/libreoffice-fs/src/lib/libreofficeFs.ts
+++ b/libs/binary/libreoffice-fs/src/lib/libreofficeFs.ts
@@ -23,6 +23,7 @@ export async function libreofficeFs({
       convertTo: body.convertTo,
       outputFilter: body.outputFilter,
       filterOptions: body.filterOptions,
+      timeoutMs: body.timeoutMs,
     });
 
     return {

--- a/libs/binary/libreoffice-fs/src/lib/schema.ts
+++ b/libs/binary/libreoffice-fs/src/lib/schema.ts
@@ -8,6 +8,7 @@ export const schema = z
     convertTo: z.enum(ConvertTo).optional().default(ConvertTo.pdf),
     outputFilter: z.string().optional(),
     filterOptions: z.union([z.string(), z.array(z.string())]).optional(),
+    timeoutMs: z.coerce.number().int().positive().optional(),
   })
   .refine(
     (data) => {

--- a/libs/binary/libreoffice/src/lib/libreoffice.ts
+++ b/libs/binary/libreoffice/src/lib/libreoffice.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, extname, resolve } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 import { finished } from 'node:stream/promises';
-import { type InputType, streamInputToWriteable, streamToBuffer } from '@riwi/stream';
+import { type InputType, processTracker, streamInputToWriteable, streamToBuffer } from '@riwi/stream';
 import type { Schema } from './schema';
 
 async function cleanup(filePath: string, type: 'file' | 'dir'): Promise<void> {
@@ -60,10 +60,13 @@ export async function libreoffice({
   convertTo,
   outputFilter,
   filterOptions,
+  timeoutMs,
 }: {
   input: InputType;
   output?: Writable | string;
 } & Schema): Promise<undefined | Buffer> {
+  let trackedProcessId: string | undefined;
+
   if (filterOptions && !outputFilter) {
     throw new Error('filterOptions requires outputFilter');
   }
@@ -111,7 +114,29 @@ export async function libreoffice({
       inFile,
     ]);
 
+    trackedProcessId = processTracker.register(unoconvert);
+    let timedOut = false;
+    const timeoutHandle =
+      timeoutMs !== undefined
+        ? setTimeout(() => {
+            timedOut = true;
+            processTracker.kill(trackedProcessId, 'SIGKILL');
+          }, timeoutMs)
+        : undefined;
+
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const complete = (fn: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
+        fn();
+      };
+
       unoconvert.stdout.on('data', (data) => {
         console.info(`libreoffice.stdout: ${data}`);
       });
@@ -122,15 +147,21 @@ export async function libreoffice({
       });
       unoconvert.on('close', (code) => {
         if (code !== 0) {
-          reject(new Error(`LibreOffice conversion failed with exit code ${code}`));
+          complete(() => {
+            if (timedOut && timeoutMs !== undefined) {
+              reject(new Error(`LibreOffice conversion timed out after ${timeoutMs}ms${stderr ? `: ${stderr}` : ''}`));
+              return;
+            }
+            reject(new Error(`LibreOffice conversion failed with exit code ${code}${stderr ? `: ${stderr}` : ''}`));
+          });
         } else if (!existsSync(outDir)) {
-          reject(new Error(`LibreOffice conversion failed, output directory not found: ${outDir}`));
+          complete(() => reject(new Error(`LibreOffice conversion failed, output directory not found: ${outDir}`)));
         } else {
-          resolve();
+          complete(resolve);
         }
       });
       unoconvert.on('error', (error) => {
-        reject(new Error(`LibreOffice process error: ${error.message}: ${stderr}`));
+        complete(() => reject(new Error(`LibreOffice process error: ${error.message}: ${stderr}`)));
       });
     });
 
@@ -156,6 +187,16 @@ export async function libreoffice({
     const buffer = await streamToBuffer(createReadStream(convertedFilePath));
 
     return buffer;
+  } catch (error) {
+    if (trackedProcessId) {
+      const trackedProcess = processTracker.get(trackedProcessId);
+      if (trackedProcess && trackedProcess.status === 'completed') {
+        trackedProcess.status = 'failed';
+        trackedProcess.exitCode = trackedProcess.exitCode ?? 1;
+        trackedProcess.endTime = trackedProcess.endTime ?? new Date();
+      }
+    }
+    throw error;
   } finally {
     if (!filesystemMode) {
       await cleanup(inFile, 'file');

--- a/libs/binary/libreoffice/src/lib/schema.ts
+++ b/libs/binary/libreoffice/src/lib/schema.ts
@@ -6,6 +6,7 @@ export const schema = z
     convertTo: z.enum(ConvertTo).optional().default(ConvertTo.pdf),
     outputFilter: z.string().optional(),
     filterOptions: z.union([z.string(), z.array(z.string())]).optional(),
+    timeoutMs: z.coerce.number().int().positive().optional(),
   })
   .refine(
     (data) => {

--- a/libs/binary/unoserver/src/lib/schema.ts
+++ b/libs/binary/unoserver/src/lib/schema.ts
@@ -12,6 +12,7 @@ export const schema = z
     inputFilter: z.string().optional(),
     outputFilter: z.string().optional(),
     filterOptions: z.union([z.string(), z.array(z.string())]).optional(),
+    timeoutMs: z.coerce.number().int().positive().optional(),
     updateIndex: booleanLiteral,
     dontUpdateIndex: booleanLiteral,
     verbose: booleanLiteral,

--- a/libs/binary/unoserver/src/lib/unoconvert.ts
+++ b/libs/binary/unoserver/src/lib/unoconvert.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import type { Writable } from 'node:stream';
-import { type InputType, streamChildProcess, streamChildProcessToBuffer } from '@riwi/stream';
+import { type InputType, processTracker, streamChildProcess, streamChildProcessToBuffer } from '@riwi/stream';
 import type { Schema } from './schema';
 
 export function unoconvert(options: { input: InputType; output: Writable } & Schema): void;
@@ -12,6 +12,7 @@ export function unoconvert({
   inputFilter,
   outputFilter,
   filterOptions,
+  timeoutMs,
   updateIndex,
   dontUpdateIndex,
   verbose,
@@ -44,8 +45,22 @@ export function unoconvert({
 
   // Spawn the unoconvert process with the provided arguments
   const unoconvert = spawn('unoconvert', args);
+  const trackedProcessId = processTracker.register(unoconvert);
+  const timeoutHandle =
+    timeoutMs !== undefined
+      ? setTimeout(() => {
+          processTracker.kill(trackedProcessId, 'SIGKILL');
+        }, timeoutMs)
+      : undefined;
+
+  const clearTimeoutHandle = () => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  };
+
   if (output) {
-    return streamChildProcess(input, output, unoconvert);
+    return streamChildProcess(input, output, unoconvert, { track: false }).finally(clearTimeoutHandle);
   }
-  return streamChildProcessToBuffer(input, unoconvert);
+  return streamChildProcessToBuffer(input, unoconvert, { track: false }).finally(clearTimeoutHandle);
 }

--- a/libs/stream/src/lib/process-tracker.ts
+++ b/libs/stream/src/lib/process-tracker.ts
@@ -54,7 +54,6 @@ export class ProcessTracker {
   /**
    * Register a child process for tracking.
    * Extracts command and args from the child process automatically.
-   * @returns The UUID assigned to this process
    */
   register(child: ChildProcessWithoutNullStreams): string {
     // Cleanup old processes before registering new ones
@@ -115,11 +114,12 @@ export class ProcessTracker {
 
   /**
    * Kill a running process.
-   * @param id The process UUID
-   * @param signal The signal to send (default: SIGTERM)
-   * @returns true if the process was found and kill signal was sent
    */
-  kill(id: string, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+  kill(id: string | undefined, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    if (!id) {
+      return false;
+    }
+
     const child = this.childRefs.get(id);
     const process = this.processes.get(id);
 
@@ -174,8 +174,6 @@ export class ProcessTracker {
 
   /**
    * Clear completed/failed/killed processes.
-   * @param olderThanMs Only clear processes older than this many milliseconds (optional)
-   * @returns The number of processes cleared
    */
   clear(olderThanMs?: number): number {
     let cleared = 0;

--- a/libs/test/bun/src/lib/process-endpoints-test.ts
+++ b/libs/test/bun/src/lib/process-endpoints-test.ts
@@ -1,6 +1,16 @@
 import { expect, it } from 'bun:test';
 import { testRequest } from '@riwi/test/request';
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tryTrigger = async (trigger: ((port: number) => Promise<void>) | undefined, port: number): Promise<void> => {
+  try {
+    await trigger?.(port);
+  } catch {
+    // Intentionally ignored: failing and timeout scenarios can close connections abruptly.
+  }
+};
+
 interface ProcessInfo {
   id: string;
   command: string;
@@ -61,6 +71,10 @@ export const createProcessEndpointsDisabledTest = (getPort: () => number): void 
 export const createProcessEndpointTests = (
   getPort: () => number,
   triggerProcess: (port: number) => Promise<void>,
+  options?: {
+    triggerFailingProcess?: (port: number) => Promise<void>;
+    triggerTimeoutProcess?: (port: number) => Promise<void>;
+  },
 ): void => {
   it('should list processes (empty initially or with existing)', async () => {
     const [response, text] = await testRequest({
@@ -213,4 +227,112 @@ export const createProcessEndpointTests = (
 
     expect(response.statusCode).toBe(404);
   });
+
+  if (options?.triggerFailingProcess) {
+    it('should track failed processes', async () => {
+      const [beforeResponse, beforeText] = await testRequest({
+        method: 'GET',
+        host: 'localhost',
+        port: getPort(),
+        path: '/processes',
+      });
+      expect(beforeResponse.statusCode).toBe(200);
+      const beforeJson = JSON.parse(beforeText) as ProcessListResponse;
+
+      await tryTrigger(options.triggerFailingProcess, getPort());
+
+      let failedCount = beforeJson.summary.failed;
+      const deadline = Date.now() + 10_000;
+
+      while (Date.now() < deadline) {
+        const [response, text] = await testRequest({
+          method: 'GET',
+          host: 'localhost',
+          port: getPort(),
+          path: '/processes',
+        });
+        expect(response.statusCode).toBe(200);
+        const json = JSON.parse(text) as ProcessListResponse;
+        failedCount = json.summary.failed;
+
+        if (failedCount > beforeJson.summary.failed) {
+          break;
+        }
+
+        await wait(100);
+      }
+
+      expect(failedCount).toBeGreaterThan(beforeJson.summary.failed);
+
+      const [failedResponse, failedText] = await testRequest({
+        method: 'GET',
+        host: 'localhost',
+        port: getPort(),
+        path: '/processes?status=failed',
+      });
+      expect(failedResponse.statusCode).toBe(200);
+
+      const failedJson = JSON.parse(failedText) as ProcessListResponse;
+      expect(failedJson.processes.length).toBeGreaterThan(0);
+
+      for (const process of failedJson.processes) {
+        expect(process.status).toBe('failed');
+        expect(process.endTime).toBeDefined();
+      }
+    });
+  }
+
+  if (options?.triggerTimeoutProcess) {
+    it('should mark timed out process as killed', async () => {
+      const [beforeResponse, beforeText] = await testRequest({
+        method: 'GET',
+        host: 'localhost',
+        port: getPort(),
+        path: '/processes',
+      });
+      expect(beforeResponse.statusCode).toBe(200);
+      const beforeJson = JSON.parse(beforeText) as ProcessListResponse;
+
+      await tryTrigger(options.triggerTimeoutProcess, getPort());
+
+      let killedCount = beforeJson.summary.killed;
+      const deadline = Date.now() + 10_000;
+
+      while (Date.now() < deadline) {
+        const [response, text] = await testRequest({
+          method: 'GET',
+          host: 'localhost',
+          port: getPort(),
+          path: '/processes',
+        });
+        expect(response.statusCode).toBe(200);
+        const json = JSON.parse(text) as ProcessListResponse;
+        killedCount = json.summary.killed;
+
+        if (killedCount > beforeJson.summary.killed) {
+          break;
+        }
+
+        await wait(100);
+      }
+
+      expect(killedCount).toBeGreaterThan(beforeJson.summary.killed);
+
+      const [killedResponse, killedText] = await testRequest({
+        method: 'GET',
+        host: 'localhost',
+        port: getPort(),
+        path: '/processes?status=killed',
+      });
+      expect(killedResponse.statusCode).toBe(200);
+
+      const killedJson = JSON.parse(killedText) as ProcessListResponse;
+      expect(killedJson.processes.length).toBeGreaterThan(0);
+
+      for (const process of killedJson.processes) {
+        expect(process.status).toBe('killed');
+        expect(process.endTime).toBeDefined();
+      }
+    });
+  }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `timeoutMs` parameter to `/convert`, `/direct`, and `/direct-fs` endpoints to enforce conversion timeouts.
  * Timed-out conversions are force-killed and tracked as "killed" in process management via `/processes?status=killed`.

* **Documentation**
  * Updated README with timeout behavior documentation and process management details.

* **Tests**
  * Added test coverage for timeout and failure scenarios in process endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->