### PR TITLE
Handle Puppeteer browser disconnects and relaunch

### DIFF
--- a/libs/binary/puppeteer/src/lib/render-to.spec.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.spec.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+afterEach(() => {
+  mock.restore();
+  delete process.env.PUPPETEER_EXECUTABLE_PATH;
+});
+
+describe('BrowserToPdfRenderer', () => {
+  it('close does not relaunch browser after intentional shutdown', async () => {
+    process.env.PUPPETEER_EXECUTABLE_PATH = '/tmp/chromium';
+
+    const disconnectedHandlers: Array<() => void | Promise<void>> = [];
+    const fakeBrowser = {
+      connected: true,
+      process: () => undefined,
+      on: (_event: string, handler: () => void | Promise<void>) => {
+        disconnectedHandlers.push(handler);
+      },
+      close: mock(async () => {
+        fakeBrowser.connected = false;
+        for (const handler of disconnectedHandlers) {
+          await handler();
+        }
+      }),
+    };
+
+    const launchMock = mock(async () => fakeBrowser);
+    mock.module('puppeteer-core', () => ({
+      default: { launch: launchMock },
+    }));
+
+    const { BrowserToPdfRenderer } = await import('./render-to');
+    const renderer = new BrowserToPdfRenderer();
+
+    await renderer.launch();
+    await renderer.close();
+
+    expect(launchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/binary/puppeteer/src/lib/render-to.spec.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.spec.ts
@@ -107,4 +107,54 @@ describe('BrowserToPdfRenderer', () => {
 
     expect(launchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('starts a new recovery when replacement browser is immediately disconnected', async () => {
+    process.env.PUPPETEER_EXECUTABLE_PATH = '/tmp/chromium';
+
+    const firstBrowser = {
+      connected: true,
+      process: () => undefined,
+      on: mock((_event: string, _handler: () => void | Promise<void>) => {}),
+      close: mock(async () => {
+        firstBrowser.connected = false;
+      }),
+    };
+    const secondBrowser = {
+      connected: false,
+      process: () => undefined,
+      on: mock((_event: string, _handler: () => void | Promise<void>) => {}),
+      close: mock(async () => {
+        secondBrowser.connected = false;
+      }),
+    };
+    const thirdBrowser = {
+      connected: true,
+      process: () => undefined,
+      on: mock((_event: string, _handler: () => void | Promise<void>) => {}),
+      close: mock(async () => {
+        thirdBrowser.connected = false;
+      }),
+    };
+
+    const launchMock = mock(async () => firstBrowser)
+      .mockImplementationOnce(async () => firstBrowser)
+      .mockImplementationOnce(async () => secondBrowser)
+      .mockImplementationOnce(async () => thirdBrowser);
+    mock.module('puppeteer-core', () => ({
+      default: { launch: launchMock },
+    }));
+
+    const { BrowserToPdfRenderer } = await import('./render-to');
+    const renderer = new BrowserToPdfRenderer();
+
+    await renderer.launch();
+    firstBrowser.connected = false;
+
+    const recovered = await (renderer as unknown as { browser: () => Promise<unknown> }).browser();
+
+    expect(recovered).toBe(thirdBrowser);
+    expect(firstBrowser.close).toHaveBeenCalledTimes(1);
+    expect(secondBrowser.close).toHaveBeenCalledTimes(1);
+    expect(launchMock).toHaveBeenCalledTimes(3);
+  });
 });

--- a/libs/binary/puppeteer/src/lib/render-to.spec.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.spec.ts
@@ -59,4 +59,52 @@ describe('BrowserToPdfRenderer', () => {
 
     expect(launchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('does not relaunch when close interleaves with in-flight recovery cleanup', async () => {
+    process.env.PUPPETEER_EXECUTABLE_PATH = '/tmp/chromium';
+
+    let resolveClose: (() => void) | undefined;
+    const closeGate = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+
+    const firstBrowser = {
+      connected: true,
+      process: () => undefined,
+      on: mock((_event: string, _handler: () => void | Promise<void>) => {}),
+      close: mock(async () => {
+        firstBrowser.connected = false;
+        await closeGate;
+      }),
+    };
+
+    const launchMock = mock(async () => firstBrowser);
+    mock.module('puppeteer-core', () => ({
+      default: { launch: launchMock },
+    }));
+
+    const { BrowserToPdfRenderer } = await import('./render-to');
+    const renderer = new BrowserToPdfRenderer();
+
+    await renderer.launch();
+    firstBrowser.connected = false;
+
+    const recoveryPromise = (renderer as unknown as { browser: () => Promise<unknown> }).browser();
+    const closePromise = renderer.close();
+
+    let isCloseResolved = false;
+    void closePromise.then(() => {
+      isCloseResolved = true;
+    });
+
+    await Promise.resolve();
+    expect(isCloseResolved).toBe(false);
+
+    resolveClose?.();
+
+    await recoveryPromise;
+    await closePromise;
+
+    expect(launchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libs/binary/puppeteer/src/lib/render-to.spec.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.spec.ts
@@ -6,25 +6,32 @@ afterEach(() => {
 });
 
 describe('BrowserToPdfRenderer', () => {
-  it('close does not relaunch browser after intentional shutdown', async () => {
+  it('uses one disconnect handler, serializes recovery, and does not relaunch on close', async () => {
     process.env.PUPPETEER_EXECUTABLE_PATH = '/tmp/chromium';
 
     const disconnectedHandlers: Array<() => void | Promise<void>> = [];
-    const fakeBrowser = {
+    const firstBrowser = {
       connected: true,
       process: () => undefined,
       on: (_event: string, handler: () => void | Promise<void>) => {
         disconnectedHandlers.push(handler);
       },
       close: mock(async () => {
-        fakeBrowser.connected = false;
-        for (const handler of disconnectedHandlers) {
-          await handler();
-        }
+        firstBrowser.connected = false;
+      }),
+    };
+    const secondBrowser = {
+      connected: true,
+      process: () => undefined,
+      on: mock((_event: string, _handler: () => void | Promise<void>) => {}),
+      close: mock(async () => {
+        secondBrowser.connected = false;
       }),
     };
 
-    const launchMock = mock(async () => fakeBrowser);
+    const launchMock = mock(async () => firstBrowser)
+      .mockImplementationOnce(async () => firstBrowser)
+      .mockImplementationOnce(async () => secondBrowser);
     mock.module('puppeteer-core', () => ({
       default: { launch: launchMock },
     }));
@@ -33,8 +40,23 @@ describe('BrowserToPdfRenderer', () => {
     const renderer = new BrowserToPdfRenderer();
 
     await renderer.launch();
+    await renderer.launch();
+
+    expect(disconnectedHandlers).toHaveLength(1);
+
+    firstBrowser.connected = false;
+    const [recoveredA, recoveredB] = await Promise.all([
+      (renderer as unknown as { browser: () => Promise<unknown> }).browser(),
+      (renderer as unknown as { browser: () => Promise<unknown> }).browser(),
+    ]);
+
+    expect(recoveredA).toBe(secondBrowser);
+    expect(recoveredB).toBe(secondBrowser);
+    expect(firstBrowser.close).toHaveBeenCalledTimes(1);
+    expect(launchMock).toHaveBeenCalledTimes(2);
+
     await renderer.close();
 
-    expect(launchMock).toHaveBeenCalledTimes(1);
+    expect(launchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -9,13 +9,19 @@ export class BrowserToPdfRenderer {
   private launchedBrowser?: Browser;
   private isClosing = false;
   private recoveringBrowser?: Promise<Browser>;
+  private recoveringFromBrowser?: Browser;
   private readonly disconnectHandlerBrowsers = new WeakSet<Browser>();
 
-  private recoverBrowser(disconnectedBrowser: Browser, timeout: number): Promise<Browser> {
-    if (this.recoveringBrowser) {
+  private recoverBrowser(
+    disconnectedBrowser: Browser,
+    timeout: number,
+    { reuseInFlight = true }: { reuseInFlight?: boolean } = {},
+  ): Promise<Browser> {
+    if (reuseInFlight && this.recoveringBrowser && this.recoveringFromBrowser === disconnectedBrowser) {
       return this.recoveringBrowser;
     }
-    this.recoveringBrowser = (async () => {
+
+    const recovery = (async () => {
       if (this.isClosing) {
         return disconnectedBrowser;
       }
@@ -23,14 +29,29 @@ export class BrowserToPdfRenderer {
       if (this.isClosing) {
         return disconnectedBrowser;
       }
-      return this.browser({ timeout });
-    })().finally(() => {
-      this.recoveringBrowser = undefined;
+      return this.browser({ timeout, reuseRecovery: false });
+    })();
+
+    this.recoveringBrowser = recovery;
+    this.recoveringFromBrowser = disconnectedBrowser;
+
+    recovery.finally(() => {
+      if (this.recoveringBrowser === recovery) {
+        this.recoveringBrowser = undefined;
+        this.recoveringFromBrowser = undefined;
+      }
     });
-    return this.recoveringBrowser;
+
+    return recovery;
   }
 
-  private async browser({ timeout = 60_000 }: { timeout?: number } = {}): Promise<Browser> {
+  private async browser({
+    timeout = 60_000,
+    reuseRecovery = true,
+  }: {
+    timeout?: number;
+    reuseRecovery?: boolean;
+  } = {}): Promise<Browser> {
     if (!this.launchedBrowser) {
       if (process.env.PUPPETEER_EXECUTABLE_PATH === undefined) {
         throw new Error('PUPPETEER_EXECUTABLE_PATH is required');
@@ -66,7 +87,7 @@ export class BrowserToPdfRenderer {
     }
 
     if (!activeBrowser.connected) {
-      return this.recoverBrowser(activeBrowser, timeout).catch((error: unknown) => {
+      return this.recoverBrowser(activeBrowser, timeout, { reuseInFlight: reuseRecovery }).catch((error: unknown) => {
         const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
         process.stderr.write(`${message}\n`);
         throw error;

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -8,6 +8,25 @@ import { ScreenshotType } from './screenshot-type';
 export class BrowserToPdfRenderer {
   private launchedBrowser?: Browser;
   private isClosing = false;
+  private recoveringBrowser?: Promise<Browser>;
+  private readonly disconnectHandlerBrowsers = new WeakSet<Browser>();
+
+  private recoverBrowser(disconnectedBrowser: Browser, timeout: number): Promise<Browser> {
+    if (this.recoveringBrowser) {
+      return this.recoveringBrowser;
+    }
+    this.recoveringBrowser = (async () => {
+      if (this.isClosing) {
+        return disconnectedBrowser;
+      }
+      await this.cleanup(disconnectedBrowser);
+      return this.browser({ timeout });
+    })().finally(() => {
+      this.recoveringBrowser = undefined;
+    });
+    return this.recoveringBrowser;
+  }
+
   private async browser({ timeout = 60_000 }: { timeout?: number } = {}): Promise<Browser> {
     if (!this.launchedBrowser) {
       if (process.env.PUPPETEER_EXECUTABLE_PATH === undefined) {
@@ -31,26 +50,26 @@ export class BrowserToPdfRenderer {
       this.launchedBrowser.process()?.stdout?.pipe(process.stdout);
       this.launchedBrowser.process()?.stderr?.pipe(process.stderr);
     }
-    const cleanupHandler = async () => {
-      if (this.isClosing) {
-        if (this.launchedBrowser) {
-          return this.launchedBrowser;
-        }
-        throw new Error('browser is closing');
-      }
-      await this.cleanup();
-      return this.browser({ timeout });
-    };
-    this.launchedBrowser.on('disconnected', () => {
-      cleanupHandler().catch((error: unknown) => {
+
+    const activeBrowser = this.launchedBrowser;
+    if (!this.disconnectHandlerBrowsers.has(activeBrowser)) {
+      this.disconnectHandlerBrowsers.add(activeBrowser);
+      activeBrowser.on('disconnected', () => {
+        this.recoverBrowser(activeBrowser, timeout).catch((error: unknown) => {
+          const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+          process.stderr.write(`${message}\n`);
+        });
+      });
+    }
+
+    if (!activeBrowser.connected) {
+      return this.recoverBrowser(activeBrowser, timeout).catch((error: unknown) => {
         const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
         process.stderr.write(`${message}\n`);
+        throw error;
       });
-    });
-    if (!this.launchedBrowser.connected) {
-      return cleanupHandler();
     }
-    return this.launchedBrowser;
+    return activeBrowser;
   }
 
   public async launch(): Promise<void> {
@@ -60,15 +79,17 @@ export class BrowserToPdfRenderer {
   public async close(): Promise<void> {
     this.isClosing = true;
     try {
-      await this.cleanup();
+      await this.cleanup(this.launchedBrowser);
     } finally {
       this.isClosing = false;
     }
   }
 
-  private async cleanup(): Promise<void> {
-    await this.launchedBrowser?.close().catch(() => {});
-    this.launchedBrowser = undefined;
+  private async cleanup(browser = this.launchedBrowser): Promise<void> {
+    await browser?.close().catch(() => {});
+    if (browser && this.launchedBrowser === browser) {
+      this.launchedBrowser = undefined;
+    }
   }
 
   public async renderTo(

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -7,6 +7,7 @@ import { ScreenshotType } from './screenshot-type';
 
 export class BrowserToPdfRenderer {
   private launchedBrowser?: Browser;
+  private isClosing = false;
   private async browser({ timeout = 60_000 }: { timeout?: number } = {}): Promise<Browser> {
     if (!this.launchedBrowser) {
       if (process.env.PUPPETEER_EXECUTABLE_PATH === undefined) {
@@ -31,6 +32,12 @@ export class BrowserToPdfRenderer {
       this.launchedBrowser.process()?.stderr?.pipe(process.stderr);
     }
     const cleanupHandler = async () => {
+      if (this.isClosing) {
+        if (this.launchedBrowser) {
+          return this.launchedBrowser;
+        }
+        throw new Error('browser is closing');
+      }
       await this.cleanup();
       return this.browser({ timeout });
     };
@@ -51,8 +58,11 @@ export class BrowserToPdfRenderer {
   }
 
   public async close(): Promise<void> {
-    if (this.launchedBrowser) {
-      await this.launchedBrowser.close();
+    this.isClosing = true;
+    try {
+      await this.cleanup();
+    } finally {
+      this.isClosing = false;
     }
   }
 

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -30,6 +30,14 @@ export class BrowserToPdfRenderer {
       this.launchedBrowser.process()?.stdout?.pipe(process.stdout);
       this.launchedBrowser.process()?.stderr?.pipe(process.stderr);
     }
+    const cleanupHandler = async () => {
+      await this.cleanup();
+      return this.browser({ timeout });
+    };
+    this.launchedBrowser.on('disconnected', cleanupHandler);
+    if (!this.launchedBrowser.connected) {
+      return cleanupHandler();
+    }
     return this.launchedBrowser;
   }
 
@@ -41,6 +49,11 @@ export class BrowserToPdfRenderer {
     if (this.launchedBrowser) {
       await this.launchedBrowser.close();
     }
+  }
+
+  private async cleanup(): Promise<void> {
+    await this.launchedBrowser?.close().catch(() => {});
+    this.launchedBrowser = undefined;
   }
 
   public async renderTo(

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -34,7 +34,12 @@ export class BrowserToPdfRenderer {
       await this.cleanup();
       return this.browser({ timeout });
     };
-    this.launchedBrowser.on('disconnected', cleanupHandler);
+    this.launchedBrowser.on('disconnected', () => {
+      cleanupHandler().catch((error: unknown) => {
+        const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+        process.stderr.write(`${message}\n`);
+      });
+    });
     if (!this.launchedBrowser.connected) {
       return cleanupHandler();
     }

--- a/libs/binary/puppeteer/src/lib/render-to.ts
+++ b/libs/binary/puppeteer/src/lib/render-to.ts
@@ -20,6 +20,9 @@ export class BrowserToPdfRenderer {
         return disconnectedBrowser;
       }
       await this.cleanup(disconnectedBrowser);
+      if (this.isClosing) {
+        return disconnectedBrowser;
+      }
       return this.browser({ timeout });
     })().finally(() => {
       this.recoveringBrowser = undefined;
@@ -79,7 +82,9 @@ export class BrowserToPdfRenderer {
   public async close(): Promise<void> {
     this.isClosing = true;
     try {
+      await this.recoveringBrowser?.catch(() => {});
       await this.cleanup(this.launchedBrowser);
+      await this.recoveringBrowser?.catch(() => {});
     } finally {
       this.isClosing = false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF rendering recovery when the browser disconnects unexpectedly.
  * Automatically closes stale browser sessions and relaunches them when needed.
  * Added handling for browsers that are already disconnected immediately after launch.
  * Prevented unnecessary browser relaunches while the renderer is shutting down.
  * Improved reliability when closing browser sessions, including cases where cleanup encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->